### PR TITLE
API endpoints tests and change to email db column uniqueness.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Without coverage:
 $ python manage.py test
 ```
 
+Without coverage and limited to a module inside tests/ directory
+
+```sh
+$ python manage.py test --test_name=test_endpoints.py
+```
+
 With coverage:
 
 ```sh

--- a/app/mod_api/endpoints.py
+++ b/app/mod_api/endpoints.py
@@ -1,11 +1,11 @@
 from flask import Blueprint
 from flask_restful import Resource, Api, reqparse
-
+from sqlalchemy.exc import IntegrityError
 from app import db
 from app.models import Email
 
 
-api_blueprint = Blueprint('api','/api')
+api_blueprint = Blueprint('api', __name__, url_prefix='/api')
 api = Api(api_blueprint)
 
 parser = reqparse.RequestParser()
@@ -17,9 +17,15 @@ parser.add_argument('form_data_as_json', type=str, location=['json'])
 class SignUp(Resource):
 	def post(self):
 		args = parser.parse_args()
-		email = Email(email=args.get('email'), source=args.get('source'), form_data_as_json=args.get('form_data_as_json'))
-		db.session.add(email)
-		db.session.commit()
+		if Email.query.filter(Email.email==args.get('email'), Email.source==args.get('source')).first():
+			return {'message':"Thanks for signing up"}
+		else:
+			email = Email(email=args.get('email'), source=args.get('source'), form_data_as_json=args.get('form_data_as_json'))
+			try:
+				db.session.add(email)
+				db.session.commit()
+			except IntegrityError:
+				return {'message':"Error signing up"}  , 500
 		return {'message':"Thanks for signing up"}
 
 api.add_resource(SignUp,'/sign-up')

--- a/app/mod_main/views.py
+++ b/app/mod_main/views.py
@@ -14,7 +14,7 @@ def index():
     """Landing page for users to enter emails."""
     form = SignUpForm(request.form)
     if form.validate_on_submit():
-        test = Email.query.filter_by(email=form.email.data).first()
+        test = Email.query.filter_by(email=form.email.data, source=None).first()
         if test:
             flash('Sorry that email aleady exists!', 'danger')
         else:

--- a/app/models.py
+++ b/app/models.py
@@ -2,9 +2,9 @@
 
 
 import datetime
+from sqlalchemy import UniqueConstraint
 
 from app import db, bcrypt
-
 
 class User(db.Model):
 
@@ -43,10 +43,12 @@ class Email(db.Model):
     __tablename__ = 'emails'
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    email = db.Column(db.String, unique=True, nullable=False)
+    email = db.Column(db.String, nullable=False)
     email_added_on = db.Column(db.DateTime, nullable=False)
     source = db.Column(db.String)
     form_data_as_json = db.Column(db.String)
+
+    __table_args__ = (UniqueConstraint('email', 'source', name='_email_source_unique_contraint'),)
 
     def __init__(self, email, source=None, form_data_as_json=None):
         self.email = email

--- a/manage.py
+++ b/manage.py
@@ -24,9 +24,12 @@ manager.add_command('db', MigrateCommand)
 
 
 @manager.command
-def test():
+def test(test_name=None):
     """Runs the unit tests without test coverage."""
-    tests = unittest.TestLoader().discover('tests')
+    if not test_name:
+        tests = unittest.TestLoader().discover('tests')
+    else:
+        tests = unittest.TestLoader().loadTestsFromName('tests.' + test_name)
     result = unittest.TextTestRunner(verbosity=2).run(tests)
     if result.wasSuccessful():
         sys.exit(0)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,86 @@
+# tests/test_endpoints.py
+
+
+import unittest
+
+import json
+from base import BaseTestCase
+from app import db
+from app.models import Email
+
+class TestApi(BaseTestCase):
+    def test_api_sign_up(self):
+        # Ensure email can be added through API
+        test_email = "test@email.com"
+        with self.client:
+            response = self.client.post('/api/sign-up',
+                    content_type='application/json',
+                    json={"email":test_email}
+                    )
+            self.assertEqual(response.status_code, 200)
+        self.assertTrue(Email.query.filter(Email.email == test_email).first())
+        # Ensure source can be added through API
+        test_email = "test1@email.com"
+        source = "somewebsite.com"
+        with self.client:
+            response = self.client.post('/api/sign-up',
+                    content_type='application/json',
+                    json={"email":test_email,"source":source}
+                    )
+            self.assertEqual(response.status_code, 200)
+        self.assertTrue(Email.query.filter(Email.email == test_email, Email.source==source).first())
+        # Ensure form_data_as_json can be added through API
+        test_email = "peter.parker@pumpkineater.com"
+        first_name, last_name = "Peter", "Parker"
+        source = "somewebsite.com"
+        json_str = json.dumps({'first_name':first_name,'last_name':last_name})
+        with self.client:
+            response = self.client.post('/api/sign-up',
+                    content_type='application/json',
+                    json={
+                        "email":test_email,
+                        "source":source,
+                        "form_data_as_json": json_str}
+                    )
+            self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+                Email.query.filter(Email.email == test_email,
+                Email.source==source,
+                Email.form_data_as_json==json_str).first()
+                )
+    def test_unique_contraint(self):
+        # Ensure email with no source is not added twice
+        test_email = "test2@email.com"
+        with self.client:
+            response = self.client.post('/api/sign-up',
+                    content_type='application/json',
+                    json={"email":test_email}
+                    )
+            self.assertEqual(response.status_code, 200)
+        self.assertTrue(Email.query.filter(Email.email == test_email).one())
+        with self.client:
+            response = self.client.post('/api/sign-up',
+                    content_type='application/json',
+                    json={"email":test_email}
+                    )
+            self.assertEqual(response.status_code, 200)
+        self.assertTrue(Email.query.filter(Email.email == test_email).one())
+        test_email = "test3@email.com"
+        source = "the-source.com"
+        with self.client:
+            response = self.client.post('/api/sign-up',
+                    content_type='application/json',
+                    json={"email":test_email,"source":source}
+                    )
+            self.assertEqual(response.status_code, 200)
+        self.assertTrue(Email.query.filter(Email.email == test_email).one())
+        with self.client:
+            response = self.client.post('/api/sign-up',
+                    content_type='application/json',
+                    json={"email":test_email, "source":source}
+                    )
+            self.assertEqual(response.status_code, 200)
+        self.assertTrue(Email.query.filter(Email.email == test_email).one())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added a unique constraint to Email.email and Email.source columns, so that it's possible to capture the same email from different sources.